### PR TITLE
Updating to node version 11.1 and all outdated dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ cat examples/settings.sample.json
     "listenPort": 7000,
     "forwardPort": 7001,
     "forwardHost": "localhost",
-    "configRefreshInterval": 60000,
+    "configRefreshInterval": 0,
     "configEndpoint": "file:./examples/limits-config.sample.json"
 }
 ```
@@ -140,8 +140,8 @@ The limits configuration is periodically loaded by the `reverse-proxy-rate-limit
 The rate-limiter can be run directly (`node start-rate-limiter.js -c settings.sample.json`) or within another project that depends on it. In the latter case, you can listen to events - to implement monitoring, for example - like this:
 
 ```javascript
-var rateLimiter = require("reverse-proxy-rate-limiter");
-var rl = rateLimiter.createRateLimiter(settings);
+const rateLimiter = require("reverse-proxy-rate-limiter");
+const rl = rateLimiter.createRateLimiter(settings);
 rl.proxyEvent.on('rejected', function(req, errorCode, reason) {
     console.log('Rejected: ', reason);
 });

--- a/examples/mock-server.js
+++ b/examples/mock-server.js
@@ -1,12 +1,12 @@
 (function () {
-    "use strict"; 
+    "use strict";
 
-    var http = require("http");
+    const http = require("http");
 
     function handler(req, res) {
-        var status_code = 200;
+        const status_code = 200;
 
-        var body = "";
+        let body = "";
         body += "Hello ratelimiter!\n";
         body += req.url + "\n";
         body += JSON.stringify(req.headers, true, 2);
@@ -28,4 +28,4 @@
             handler(req, res);
         }
     }).listen(7001);
-})()
+})();

--- a/examples/settings.sample.json
+++ b/examples/settings.sample.json
@@ -3,6 +3,6 @@
     "listenPort": 7000,
     "forwardPort": 7001,
     "forwardHost": "localhost",
-    "configRefreshInterval": 60000,
+    "configRefreshInterval": 0,
     "configEndpoint": "file:./examples/limits-config.sample.json"
 }

--- a/lib/rate-limiter.js
+++ b/lib/rate-limiter.js
@@ -1,4 +1,4 @@
-var rateLimiter = require('./reverse-proxy-rate-limiter/');
+const rateLimiter = require('./reverse-proxy-rate-limiter/');
 
 module.exports.createRateLimiter = function createRateLimiter(settings) {
     return new rateLimiter.RateLimiter(settings);

--- a/lib/reverse-proxy-rate-limiter/bucket.js
+++ b/lib/reverse-proxy-rate-limiter/bucket.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var Condition = require("./conditions/conditions").Condition;
+const Condition = require("./conditions/conditions").Condition;
 
 function Bucket(bucketConfig) {
     this.name = bucketConfig.name;
@@ -34,7 +34,7 @@ Bucket.prototype = {
     },
 
     matches: function (request) {
-        for (var i = 0; i < this.conditions.length; i++) {
+        for (let i = 0; i < this.conditions.length; i++) {
             if (!this.conditions[i].evaluate(request)) {
                 return false;
             }

--- a/lib/reverse-proxy-rate-limiter/conditions/conditions.js
+++ b/lib/reverse-proxy-rate-limiter/conditions/conditions.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var _ = require("lodash")._,
-    Predicates = require("./predicates").Predicates,
-    SubjectTypes = require("./subject-types").SubjectTypes;
+const _ = require("lodash")._;
+const Predicates = require("./predicates").Predicates;
+const SubjectTypes = require("./subject-types").SubjectTypes;
 
 exports.Condition = Condition;
 
@@ -14,12 +14,12 @@ function Condition(conditionArray) {
     }
     this.subject = findSubjectType(conditionArray[0]);
 
-    var expectedArraySize = this.subject.parameterCount + 3; // subject + subject parameters + predicate + value
+    const expectedArraySize = this.subject.parameterCount + 3; // subject + subject parameters + predicate + value
     if (conditionArray.length !== expectedArraySize) {
         throw new Error("Expected conditionArray size is " + expectedArraySize + " but was " + conditionArray.length);
     }
 
-    conditionArray = _.rest(conditionArray);
+    conditionArray = _.drop(conditionArray);
     if (this.subject.parameterCount === 0) {
         this.parameters = [];
     } else {
@@ -38,7 +38,7 @@ function Condition(conditionArray) {
 
 Condition.prototype.toString = function () {
     if (typeof this.stringValue === 'undefined') {
-        var s = "Condition[" + this.subject.name;
+        let s = "Condition[" + this.subject.name;
         if (this.parameters.length > 0) {
             s += "[" + this.parameters + "]";
         }
@@ -49,7 +49,7 @@ Condition.prototype.toString = function () {
 };
 
 Condition.prototype.evaluate = function (request) {
-    var actualValue = this.subject.extractValue(request, this.parameters);
+    const actualValue = this.subject.extractValue(request, this.parameters);
     if (actualValue === undefined) {
         return false;
     }
@@ -57,7 +57,7 @@ Condition.prototype.evaluate = function (request) {
 };
 
 function findSubjectType(subject) {
-    var ret = SubjectTypes[subject];
+    const ret = SubjectTypes[subject];
     if (ret === undefined) {
         throw new Error("Invalid subject: " + subject);
     }
@@ -65,7 +65,7 @@ function findSubjectType(subject) {
 }
 
 function findPredicate(predicate) {
-    var ret = Predicates[predicate];
+    const ret = Predicates[predicate];
     if (ret === undefined) {
         throw new Error("Invalid predicate: " + predicate);
     }

--- a/lib/reverse-proxy-rate-limiter/conditions/subject-types.js
+++ b/lib/reverse-proxy-rate-limiter/conditions/subject-types.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var Predicates = require("./predicates").Predicates,
+const Predicates = require("./predicates").Predicates,
     url = require("url");
 
-var SubjectTypes = {
+const SubjectTypes = {
     header: {
         parameterCount: 1,
         predicates: [Predicates.eq, Predicates.ne, Predicates.matches],
@@ -40,11 +40,11 @@ function extractClientIp() {
 }
 
 function extractPath(request) {
-    var urlObject = url.parse(request.url);
+    const urlObject = url.parse(request.url);
     return urlObject.pathname;
 }
 
-for (var st in SubjectTypes) {
+for (let st in SubjectTypes) {
     SubjectTypes[st].name = st;
 }
 exports.SubjectTypes = SubjectTypes;

--- a/lib/reverse-proxy-rate-limiter/counter.js
+++ b/lib/reverse-proxy-rate-limiter/counter.js
@@ -2,9 +2,9 @@
 
 exports.CounterStore = CounterStore;
 
-var BUCKET_PREFIX = "bucket:";
-var IP_PREFIX = "ip:";
-var GLOBAL_KEY = "global";
+const BUCKET_PREFIX = "bucket:";
+const IP_PREFIX = "ip:";
+const GLOBAL_KEY = "global";
 
 function CounterStore() {
     // counters : {
@@ -21,17 +21,17 @@ function CounterStore() {
 CounterStore.prototype = {
 
     getGlobalRequestCount: function () {
-        var key = GLOBAL_KEY;
+        const key = GLOBAL_KEY;
         return this.counters[key] || 0;
     },
 
     getRequestCountForBucket: function (bucket) {
-        var key = BUCKET_PREFIX + bucket.name;
+        const key = BUCKET_PREFIX + bucket.name;
         return this.counters[key] || 0;
     },
 
     getRequestCountForBucketAndIP: function (bucket, ip) {
-        var key = IP_PREFIX + bucket.name + ":" + ip;
+        const key = IP_PREFIX + bucket.name + ":" + ip;
         return this.counters[key] || 0;
     },
 
@@ -48,14 +48,14 @@ CounterStore.prototype = {
             return;
         }
 
-        var keys = getKeys(bucket, ip);
-        for (var i = 0; i < keys.length; i++) {
+        const keys = getKeys(bucket, ip);
+        for (let i = 0; i < keys.length; i++) {
             this.changeValueForKey(keys[i], incrementBy);
         }
     },
 
     changeValueForKey: function (key, incrementBy) {
-        var val;
+        let val;
         if (key in this.counters) {
             val = this.counters[key];
         } else {

--- a/lib/reverse-proxy-rate-limiter/index.js
+++ b/lib/reverse-proxy-rate-limiter/index.js
@@ -1,14 +1,14 @@
 "use strict";
 
-var _ = require("lodash"),
-    LimitsEvaluator = require("./limits-evaluator"),
-    httpProxy = require('http-proxy'),
-    http = require("http"),
-    log4js = require('log4js'),
-    EventEmitter = require('events').EventEmitter;
+const _ = require("lodash");
+const LimitsEvaluator = require("./limits-evaluator");
+const httpProxy = require('http-proxy');
+const http = require("http");
+const log4js = require('log4js');
+const EventEmitter = require('events').EventEmitter;
 
 module.exports.RateLimiter = RateLimiter;
-var logger = log4js.getLogger();
+const logger = log4js.getLogger();
 
 // http://nodejs.org/docs/v0.10.35/api/http.html#http_agent_maxsockets
 // in v0.12 maxSockets default was changed to Infinity
@@ -28,7 +28,7 @@ RateLimiter.prototype = {
 
     initProxy: function () {
         logger.info("New worker is being spawned.");
-        var _this = this;
+        const _this = this;
         this.proxy = httpProxy.createProxyServer({});
 
         this.proxy.on('proxyReq', function (proxyReq, req, res, options) {
@@ -42,11 +42,11 @@ RateLimiter.prototype = {
         });
         this.proxyEvent.on('forwarded', this.onForward.bind(this));
 
-        var server = http.createServer(function (req, res) {
-            var resultMethod = _this.evaluator.evaluate(req,
-                                            _this.makeForward.bind(_this),
-                                            _this.makeReject.bind(_this),
-                                            _this.makeHealthcheck.bind(_this));
+        const server = http.createServer(function (req, res) {
+            const resultMethod = _this.evaluator.evaluate(req,
+                _this.makeForward.bind(_this),
+                _this.makeReject.bind(_this),
+                _this.makeHealthcheck.bind(_this));
             resultMethod(req, res);
         });
         server.listen(_this.settings.listenPort, function () {
@@ -78,7 +78,7 @@ RateLimiter.prototype = {
             }
         };
 
-        for (var listener in this.processEventListeners) {
+        for (let listener in this.processEventListeners) {
             if (this.processEventListeners.hasOwnProperty(listener)) {
                 process.on(listener, this.processEventListeners[listener]);
             }
@@ -94,7 +94,7 @@ RateLimiter.prototype = {
     // responder generator
 
     makeForward: function () {
-        var _this = this;
+        const _this = this;
         return function(req, res) {
             _this.proxyEvent.emit('forwarded', req);
 
@@ -105,13 +105,13 @@ RateLimiter.prototype = {
     },
 
     makeReject: function(reason, errorCode) {
-        var _this = this;
+        const _this = this;
         errorCode = errorCode || 429;
 
         return function (req, res) {
             _this.proxyEvent.emit('rejected', req, errorCode, reason);
 
-            var handled = _this.proxyEvent.emit('rejectRequest', req, res, errorCode, reason)
+            const handled = _this.proxyEvent.emit('rejectRequest', req, res, errorCode, reason);
             if (!handled) {
                 _this.rejectRequest(req, res, errorCode, reason);
             }
@@ -146,11 +146,11 @@ RateLimiter.prototype = {
             process.send('offline');
         }
 
-        var _this = this;
+        const _this = this;
         this.server.close(function () {
             logger.info("Old worker proxy is closed.");
 
-            for (var listener in _this.processEventListeners) {
+            for (let listener in _this.processEventListeners) {
                 if (_this.processEventListeners.hasOwnProperty(listener)) {
                     process.removeListener(listener, _this.processEventListeners[listener]);
                 }

--- a/lib/reverse-proxy-rate-limiter/ipextractor.js
+++ b/lib/reverse-proxy-rate-limiter/ipextractor.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var proxyaddr = require('proxy-addr');
+const proxyaddr = require('proxy-addr');
 
 function IPExtractor(forwardHeader){
     this.internalFilter = proxyaddr.compile(forwardHeader['ignored_ip_ranges'] || []);
@@ -10,10 +10,10 @@ IPExtractor.prototype = {
 
     extractClientIP : function(header){
 
-        var ipExtractor = this;
-        var extractedIPs = this.extractIPs(header);
-        var filteredIPs =  extractedIPs.filter(function(ip){
-           return !ipExtractor.isIgnoredIP(ip);
+        const ipExtractor = this;
+        const extractedIPs = this.extractIPs(header);
+        const filteredIPs = extractedIPs.filter(function (ip) {
+            return !ipExtractor.isIgnoredIP(ip);
         });
 
         if(filteredIPs.length){

--- a/lib/reverse-proxy-rate-limiter/ipresolver.js
+++ b/lib/reverse-proxy-rate-limiter/ipresolver.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var log4js = require('log4js'),
+const log4js = require('log4js'),
     IPExtractor = require("./ipextractor").IPExtractor;
 
-var PROXY_HEADER = 'X-FORWARDED-FOR'.toLowerCase();
-var ipExtractorMap = {};
+const PROXY_HEADER = 'X-FORWARDED-FOR'.toLowerCase();
+const ipExtractorMap = {};
 
 // If the request only passed through external proxies, and maybe ELB,
 // the situation is a bit trickier. We have to go from the end of the
@@ -20,10 +20,10 @@ function IPResolver(forwardedHeadersFromSettings) {
 }
 
 IPResolver.prototype.resolve = function (req) {
-    var remoteAddress = req.socket.remoteAddress;
-    for (var key in this.forwardedHeaders) {
+    const remoteAddress = req.socket.remoteAddress;
+    for (let key in this.forwardedHeaders) {
         if (this.forwardedHeaders.hasOwnProperty(key)) {
-            var hdr = req.headers[key.toLowerCase()];
+            const hdr = req.headers[key.toLowerCase()];
             if(hdr){
                 return this.getExtractor(key).extractClientIP(hdr);
             }

--- a/lib/reverse-proxy-rate-limiter/limits-config-schema.js
+++ b/lib/reverse-proxy-rate-limiter/limits-config-schema.js
@@ -1,13 +1,13 @@
 "use strict";
 
-var Validator = require('jsonschema').Validator,
-    SchemaError = require('jsonschema').SchemaError,
-    Condition = require("./conditions/conditions").Condition;
+const Validator = require('jsonschema').Validator;
+const SchemaError = require('jsonschema').SchemaError;
+const Condition = require("./conditions/conditions").Condition;
 
 exports.validate = validate;
 
 function validate(limitsConfig) {
-    var validator = new Validator();
+    const validator = new Validator();
     validator.attributes.isCondition = validateCondition;
     validator.addSchema(bucket);
     validator.addSchema(bucketLimit);
@@ -15,7 +15,7 @@ function validate(limitsConfig) {
     return validator.validate(limitsConfig, limitsConfigSchema);
 }
 
-var limitsConfigSchema = {
+const limitsConfigSchema = {
     "id": "/LimitsConfig",
     "type": "object",
     "properties": {
@@ -31,7 +31,7 @@ var limitsConfigSchema = {
     }
 };
 
-var bucket = {
+const bucket = {
     "id": "/Buckets",
     "type": "object",
     "properties": {
@@ -44,14 +44,14 @@ var bucket = {
     }
 };
 
-var condition = {
+const condition = {
     "id": "/Condition",
     "type": "array",
     "items": {"type": "string"},
     "isCondition": true
 };
 
-var bucketLimit = {
+const bucketLimit = {
     "id": "/BucketLimit",
     "type": "object",
     "properties": {

--- a/lib/reverse-proxy-rate-limiter/limits-config.js
+++ b/lib/reverse-proxy-rate-limiter/limits-config.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var fs = require('fs'),
-    request = require("request"),
-    url = require("url"),
-    limitsConfigSchema = require('./limits-config-schema'),
-    Bucket = require("./bucket").Bucket,
-    log4js = require('log4js');
+const fs = require('fs');
+const request = require("request");
+const url = require("url");
+const limitsConfigSchema = require('./limits-config-schema');
+const Bucket = require("./bucket").Bucket;
+const log4js = require('log4js');
 
 exports.isValidConfig = isValidConfig;
 exports.LimitsConfiguration = LimitsConfiguration;
@@ -22,7 +22,7 @@ if (!isValidConfig(exports.defaultLimitsConfig)) {
     throw new Error("Invalid defaultLimitsConfig");
 }
 
-var logger = log4js.getLogger();
+const logger = log4js.getLogger();
 
 
 function LimitsConfiguration(cfg) {
@@ -35,12 +35,12 @@ function LimitsConfiguration(cfg) {
 
     this.buckets = this.initializeBuckets(cfg.buckets);
 
-    var sumOfCapacityUnits = this.calculateTotalCapacityUnits();
+    const sumOfCapacityUnits = this.calculateTotalCapacityUnits();
     this.buckets.forEach(function (bucket) {
         if (sumOfCapacityUnits === 0) {
             bucket.maxRequests = 0;
         } else {
-            var bucketCapacityRatio = bucket.capacityUnit / sumOfCapacityUnits;
+            const bucketCapacityRatio = bucket.capacityUnit / sumOfCapacityUnits;
             bucket.maxRequests = Math.ceil(this.maxRequestsWithoutBuffer * bucketCapacityRatio);
         }
     }, this);
@@ -48,11 +48,11 @@ function LimitsConfiguration(cfg) {
 
 LimitsConfiguration.prototype = {
     initializeBuckets: function (buckets) {
-        var defaultBucket = null;
-        var initializedBuckets = [];
+        let defaultBucket = null;
+        let initializedBuckets = [];
 
         buckets.forEach(function (bucketConfig) {
-            var bucket = new Bucket(bucketConfig);
+            const bucket = new Bucket(bucketConfig);
 
             if (bucket.isDefault()) {
                 if (defaultBucket !== null) {
@@ -73,7 +73,7 @@ LimitsConfiguration.prototype = {
     },
 
     calculateTotalCapacityUnits: function () {
-        var capacityUnits = 0;
+        let capacityUnits = 0;
         this.buckets.forEach(function (bucket) {
             capacityUnits += bucket.capacityUnit;
         });
@@ -90,7 +90,7 @@ function LimitsConfigurationLoader(configEndpoint) {
 LimitsConfigurationLoader.prototype = {
     load: function (callback) {
         this.limitsConfigurationSource = new LimitsConfigurationSource(this.configEndpoint);
-        var forwardValidConfigCallback = this.buildForwardValidConfigCallback(callback);
+        const forwardValidConfigCallback = this.buildForwardValidConfigCallback(callback);
 
         if (this.limitsConfigurationSource.isUrl()) {
             this.loadFromURL(this.configEndpoint, forwardValidConfigCallback);
@@ -102,7 +102,7 @@ LimitsConfigurationLoader.prototype = {
     },
 
     buildForwardValidConfigCallback: function (callback) {
-        var _this = this;
+        const _this = this;
         return function (config) {
             if (isValidConfig(config)) {
                 callback(config);
@@ -159,7 +159,7 @@ LimitsConfigurationSource.prototype = {
 };
 
 function isValidConfig(config) {
-    var result = limitsConfigSchema.validate(config);
+    const result = limitsConfigSchema.validate(config);
     if (result.errors.length > 0) {
         logger.error("Invalid config: " + result.errors);
     }

--- a/lib/reverse-proxy-rate-limiter/limits-evaluator.js
+++ b/lib/reverse-proxy-rate-limiter/limits-evaluator.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var IPResolver = require("./ipresolver").IPResolver,
+const IPResolver = require("./ipresolver").IPResolver,
     CounterStore = require("./counter").CounterStore,
     LimitsConfiguration = require("./limits-config").LimitsConfiguration,
     LimitsConfigurationLoader = require("./limits-config").LimitsConfigurationLoader,
@@ -9,7 +9,7 @@ var IPResolver = require("./ipresolver").IPResolver,
 
 module.exports = LimitsEvaluator;
 
-var logger = log4js.getLogger();
+const logger = log4js.getLogger();
 
 function LimitsEvaluator(settings, eventEmitter) {
     this.settings = settings;
@@ -32,7 +32,7 @@ function LimitsEvaluator(settings, eventEmitter) {
         if (this.settings.configRefreshInterval < 5000) {
             logger.warn("configRefreshInterval should be >= 5000 (5sec) -> automatic config update turned off");
         } else {
-            var _this = this;
+            const _this = this;
             setInterval(function () {
                 _this.loadConfig();
             }, this.settings.configRefreshInterval);
@@ -43,7 +43,7 @@ function LimitsEvaluator(settings, eventEmitter) {
 LimitsEvaluator.prototype = {
     loadConfig: function () {
         try {
-            var _this = this;
+            const _this = this;
             this.limitConfigurationLoader.load(function (cfg) {
                 if (cfg !== null) {
                     _this.updateConfig(cfg);
@@ -67,8 +67,8 @@ LimitsEvaluator.prototype = {
     // event handlers
 
     onRequestForwarded: function(req) {
-        var bucket = req.bucket;
-        var ip = req.ip;
+        const bucket = req.bucket;
+        const ip = req.ip;
 
         if (bucket && ip) {
             this.counter.increment(bucket, ip);
@@ -96,8 +96,8 @@ LimitsEvaluator.prototype = {
     },
 
     isMaxRequestsLimitReached: function () {
-        var isMaxRequestsLimitSet = this.limitsConfiguration.maxRequests > 0;
-        var isMaxRequestsLimitReached = this.counter.getGlobalRequestCount() >= this.limitsConfiguration.maxRequests;
+        const isMaxRequestsLimitSet = this.limitsConfiguration.maxRequests > 0;
+        const isMaxRequestsLimitReached = this.counter.getGlobalRequestCount() >= this.limitsConfiguration.maxRequests;
 
         if (isMaxRequestsLimitSet && isMaxRequestsLimitReached) {
             logger.info("Rejected by global limit: " + this.counter.getGlobalRequestCount());
@@ -108,8 +108,8 @@ LimitsEvaluator.prototype = {
     },
 
     isByIPLimitReached: function (bucket, ip) {
-        var isByIPLimitSet = bucket.getMaxRequestsPerIp() > 0;
-        var isByIPLimitReached = this.counter.getRequestCountForBucketAndIP(bucket, ip) >= bucket.getMaxRequestsPerIp();
+        const isByIPLimitSet = bucket.getMaxRequestsPerIp() > 0;
+        const isByIPLimitReached = this.counter.getRequestCountForBucketAndIP(bucket, ip) >= bucket.getMaxRequestsPerIp();
 
         if (isByIPLimitSet && isByIPLimitReached) {
             logger.info("Rejected by IP limit for bucket: ", bucket.name, ip);
@@ -120,14 +120,14 @@ LimitsEvaluator.prototype = {
     },
 
     isBelowMaxRequestsWithoutBuffer: function () {
-        var isGlobalRequestsUnlimited = this.limitsConfiguration.maxRequestsWithoutBuffer === 0;
-        var isBelowMaxRequestsWithoutBuffer = this.counter.getGlobalRequestCount() < this.limitsConfiguration.maxRequestsWithoutBuffer;
+        const isGlobalRequestsUnlimited = this.limitsConfiguration.maxRequestsWithoutBuffer === 0;
+        const isBelowMaxRequestsWithoutBuffer = this.counter.getGlobalRequestCount() < this.limitsConfiguration.maxRequestsWithoutBuffer;
         return isGlobalRequestsUnlimited || isBelowMaxRequestsWithoutBuffer;
     },
 
     isBucketFull: function (bucket, ip) {
-        var isBucketCapacityLimited = bucket.getMaxRequests() > 0;
-        var isBucketFull = this.counter.getRequestCountForBucket(bucket) >= this.calculateAvailableRequestsForBucket(bucket);
+        const isBucketCapacityLimited = bucket.getMaxRequests() > 0;
+        const isBucketFull = this.counter.getRequestCountForBucket(bucket) >= this.calculateAvailableRequestsForBucket(bucket);
 
         if (isBucketCapacityLimited && isBucketFull) {
             logger.info("Rejected by bucket limit: ", bucket.name, ip);
@@ -155,10 +155,10 @@ LimitsEvaluator.prototype = {
                 return returnReject("global.request_limit_reached");
             }
 
-            var bucket = this.getMatchingBucket(req);
+            const bucket = this.getMatchingBucket(req);
             req.bucket = bucket;
 
-            var ip = this.ipResolver.resolve(req);
+            const ip = this.ipResolver.resolve(req);
             req.ip = ip;
 
             if (this.isByIPLimitReached(bucket, ip)) {
@@ -189,7 +189,7 @@ LimitsEvaluator.prototype = {
     },
 
     calculateAvailableRequestCount: function () {
-        var remainingRequestCount = this.limitsConfiguration.maxRequestsWithoutBuffer;
+        let remainingRequestCount = this.limitsConfiguration.maxRequestsWithoutBuffer;
 
         this.limitsConfiguration.buckets.forEach(function (bucket) {
             if (this.counter.getRequestCountForBucket(bucket) < bucket.getMaxRequests()) {
@@ -201,7 +201,7 @@ LimitsEvaluator.prototype = {
     },
 
     calculateTotalCapacityOfCompetingBuckets: function (competingBuckets) {
-        var sumOfCapacityUnits = 0;
+        let sumOfCapacityUnits = 0;
 
         competingBuckets.forEach(function (bucket) {
             sumOfCapacityUnits += bucket.capacityUnit;
@@ -211,15 +211,15 @@ LimitsEvaluator.prototype = {
     },
 
     calculateAvailableRequestsForBucket: function (bucket) {
-        var competingBuckets = this.getCompetingBuckets();
-        var totalCapacityOfCompetingBuckets = this.calculateTotalCapacityOfCompetingBuckets(competingBuckets);
-        var availableRequestCount = this.calculateAvailableRequestCount();
+        const competingBuckets = this.getCompetingBuckets();
+        const totalCapacityOfCompetingBuckets = this.calculateTotalCapacityOfCompetingBuckets(competingBuckets);
+        const availableRequestCount = this.calculateAvailableRequestCount();
 
         return Math.ceil(availableRequestCount / totalCapacityOfCompetingBuckets * bucket.capacityUnit);
     },
 
     getMatchingBucket: function (req) {
-        for (var i = 0; i < this.limitsConfiguration.buckets.length; i++) {
+        for (let i = 0; i < this.limitsConfiguration.buckets.length; i++) {
             if (this.limitsConfiguration.buckets[i].matches(req)) {
                 return this.limitsConfiguration.buckets[i];
             }

--- a/lib/reverse-proxy-rate-limiter/settings.js
+++ b/lib/reverse-proxy-rate-limiter/settings.js
@@ -1,6 +1,6 @@
 /* global require, process */
 (function () {
-    var os = require('os'),
+    const os = require('os'),
         fs = require('fs'),
         _ = require('lodash'),
         url = require('url');
@@ -33,7 +33,7 @@
     };
 
     function maybeLoadConfigFile(path) {
-        var content;
+        let content;
         try {
             content = fs.readFileSync(path);
         } catch (e) {
@@ -46,7 +46,7 @@
     function updateDerivedSettings(settings) {
         settings.forwardUrl = "http://" + settings.forwardHost + ":" + settings.forwardPort;
 
-        var configUrl = url.parse(settings.configEndpoint);
+        let configUrl = url.parse(settings.configEndpoint);
         if (configUrl.protocol === null) {
             configUrl = url.parse(settings.forwardUrl);
             configUrl.pathname = settings.configEndpoint;
@@ -58,7 +58,7 @@
     }
 
     function load(extraConfigFile, hook) {
-        var builder = new ConfigBuilder();
+        const builder = new ConfigBuilder();
         builder.addObj(defaultConfig);
         builder.addDir("config");
         if (hook) { hook(builder); }
@@ -66,12 +66,12 @@
             builder.addFile(extraConfigFile);
         }
 
-        var settings = builder.build();
+        const settings = builder.build();
         return updateDerivedSettings(settings);
     }
 
     function init() {
-        var opts = require('nomnom')
+        const opts = require('nomnom')
             .option('config', {
                 abbr: 'c',
                 default: null,
@@ -90,23 +90,27 @@
         return this.load(opts.config);
     }
 
-    var defaultConfig = {
+    const defaultConfig = {
         "log4js": {
-            "appenders": [
-                {
+            "appenders": {
+                "console" : {
                     "type": "console",
                     "layout": {
                         "type": "pattern",
                         "pattern": "%d{ISO8601} %h %c %p %m%n"
                     }
                 }
-            ]
+            },
+            "categories": {
+                "default": {
+                    "appenders": ["console"],
+                    "level": "info" } }
         },
         "serviceName": "defaultService",
         "listenPort": 8001,
         "forwardPort": 8000,
         "forwardHost": "localhost",
-        "configRefreshInterval": 60000,
+        "configRefreshInterval": 0,
         "configEndpoint": "/rate-limiter/",
         "bucketHeaderName": "X-RateLimiter-Bucket"
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1189 @@
+{
+  "name": "reverse-proxy-rate-limiter",
+  "version": "0.1.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "ajv": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+    },
+    "ansi-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+      "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "^1.0.1"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chalk": {
+      "version": "0.4.0",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+      "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+      "requires": {
+        "ansi-styles": "~1.0.0",
+        "has-color": "~0.1.0",
+        "strip-ansi": "~0.1.0"
+      }
+    },
+    "circular-json": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
+      "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ=="
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "date-format": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
+      "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "eventemitter3": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "^0.1.0"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "^2.1.0"
+      }
+    },
+    "expect": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
+      "integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "jest-diff": "^23.6.0",
+        "jest-get-type": "^22.1.0",
+        "jest-matcher-utils": "^23.6.0",
+        "jest-message-util": "^23.4.0",
+        "jest-regex-util": "^23.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "requires": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
+      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "^2.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
+      "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "http-proxy": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "requires": {
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "^2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jest-diff": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
+      "integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
+      "requires": {
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^22.1.0",
+        "pretty-format": "^23.6.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "jest-get-type": {
+      "version": "22.4.3",
+      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
+    },
+    "jest-matcher-utils": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
+      "integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-get-type": "^22.1.0",
+        "pretty-format": "^23.6.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "23.4.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
+      "integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
+      "requires": {
+        "@babel/code-frame": "^7.0.0-beta.35",
+        "chalk": "^2.0.1",
+        "micromatch": "^2.3.11",
+        "slash": "^1.0.0",
+        "stack-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "jest-regex-util": {
+      "version": "23.3.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
+      "integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "log4js": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.6.tgz",
+      "integrity": "sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==",
+      "requires": {
+        "circular-json": "^0.5.5",
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "rfdc": "^1.1.2",
+        "streamroller": "0.7.0"
+      }
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "requires": {
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      }
+    },
+    "mime-db": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+    },
+    "mime-types": {
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "requires": {
+        "mime-db": "~1.37.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nomnom": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+      "requires": {
+        "chalk": "~0.4.0",
+        "underscore": "~1.6.0"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "pretty-format": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+      "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+      "requires": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "proxy-addr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.8.0"
+      }
+    },
+    "psl": {
+      "version": "1.1.29",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "^0.1.3"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "rfdc": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
+      "integrity": "sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA=="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
+    "sshpk": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stack-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA="
+    },
+    "streamroller": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
+      "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
+      "requires": {
+        "date-format": "^1.2.0",
+        "debug": "^3.1.0",
+        "mkdirp": "^0.5.1",
+        "readable-stream": "^2.3.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+      "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reverse-proxy-rate-limiter",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/prezi/reverse-proxy-rate-limiter.git"
@@ -17,26 +17,26 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "http-proxy": "1.13.3",
-    "jsonschema": "1.1.0",
-    "lodash": "3.3.1",
-    "log4js": "0.6.22",
+    "http-proxy": "^1.17.0",
+    "jsonschema": "^1.2.4",
+    "lodash": "^4.17.11",
+    "log4js": "^3.0.6",
     "nomnom": "1.8.1",
-    "proxy-addr": "1.1.2",
-    "request": "2.72.0"
+    "proxy-addr": "^2.0.4",
+    "request": "^2.88.0"
   },
   "devDependencies": {
-    "expect.js": "0.3.1",
-    "mocha": "2.5.3"
+    "expect": "^23.6.0",
+    "mocha": "^5.2.0"
   },
   "engines": {
-    "node": "6.0.0"
+    "node": "11.1.0"
   },
   "scripts": {
     "start": "node start-rate-limiter.js",
     "test": "mocha --recursive"
   },
-  "license": "Apache License, Version 2.0",
+  "license": "Apache-2.0",
   "jshintConfig": {
     "undef": true,
     "unused": true,

--- a/start-rate-limiter.js
+++ b/start-rate-limiter.js
@@ -1,5 +1,5 @@
 /* global require */
-var config = require('./lib/reverse-proxy-rate-limiter/settings').init(),
+const config = require('./lib/reverse-proxy-rate-limiter/settings').init(),
     rateLimiter = require('./lib/rate-limiter');
 
 rateLimiter.createRateLimiter(config);

--- a/test/bucket-test.js
+++ b/test/bucket-test.js
@@ -1,39 +1,39 @@
 "use strict";
 
-var expect = require('expect.js'),
-    fs = require('fs'),
-    LimitsEvaluator = require('../lib/reverse-proxy-rate-limiter/limits-evaluator'),
-    EventEmitter = require('events').EventEmitter,
-    Bucket = require('../lib/reverse-proxy-rate-limiter/bucket').Bucket;
+const expect = require('expect');
+const fs = require('fs');
+const LimitsEvaluator = require('../lib/reverse-proxy-rate-limiter/limits-evaluator');
+const EventEmitter = require('events').EventEmitter;
+const Bucket = require('../lib/reverse-proxy-rate-limiter/bucket').Bucket;
 
 describe("Bucket tests", function () {
-    var request = {
+    const request = {
         "url": "/test"
     };
     it("should match the bucket", function () {
-        var bucket = new Bucket({
+        const bucket = new Bucket({
             name: "testBucket",
             conditions: [
                 ["path", "eq", "/test"]
             ]
         });
 
-        expect(bucket.matches(request)).to.be(true);
+        expect(bucket.matches(request)).toBeTruthy();
     });
 
     it("should not match the bucket", function () {
-        var bucket = new Bucket({
+        const bucket = new Bucket({
             name: "testBucket",
             conditions: [
                 ["path", "eq", "/test2"]
             ]
         });
 
-        expect(bucket.matches(request)).to.be(false);
+        expect(bucket.matches(request)).toBeFalsy();
     });
 
     it("should not match if only one condition is met", function () {
-        var bucket = new Bucket({
+        const bucket = new Bucket({
             name: "testBucket",
             conditions: [
                 ["path", "eq", "/test"],
@@ -41,23 +41,23 @@ describe("Bucket tests", function () {
             ]
         });
 
-        expect(bucket.matches(request)).to.be(false);
+        expect(bucket.matches(request)).toBeFalsy();
     });
 
-    var evaluator;
+    let evaluator;
 
     it("should choose the reuse bucket", function () {
-        var b = evaluator.getMatchingBucket({headers: {"x-prezi-client": "reuse-e5759ce4bb1c298b063f2d8aa1a334"}});
-        expect(b.name).to.be("reuse");
+        const b = evaluator.getMatchingBucket({headers: {"x-prezi-client": "reuse-e5759ce4bb1c298b063f2d8aa1a334"}});
+        expect(b.name).toBe("reuse");
     });
     it("should choose the default bucket", function () {
-        var b = evaluator.getMatchingBucket();
-        expect(b.name).to.be("default");
+        const b = evaluator.getMatchingBucket();
+        expect(b.name).toBe("default");
     });
 
     before(function () {
         evaluator = new LimitsEvaluator({}, new EventEmitter());
-        evaluator.updateConfig(JSON.parse(fs.readFileSync("./test/fixtures/example_configuration.json")));
+        evaluator.updateConfig(JSON.parse(fs.readFileSync("./test/fixtures/example_configuration.json", 'utf8')));
     });
 
 });

--- a/test/condition-test.js
+++ b/test/condition-test.js
@@ -1,98 +1,98 @@
 "use strict";
 
-var expect = require('expect.js'),
-    Condition = require("../lib/reverse-proxy-rate-limiter/conditions/conditions").Condition,
-    Predicates = require("../lib/reverse-proxy-rate-limiter/conditions/predicates").Predicates,
-    SubjectTypes = require("../lib/reverse-proxy-rate-limiter/conditions/subject-types").SubjectTypes;
+const expect = require('expect');
+const Condition = require("../lib/reverse-proxy-rate-limiter/conditions/conditions").Condition;
+const Predicates = require("../lib/reverse-proxy-rate-limiter/conditions/predicates").Predicates;
+const SubjectTypes = require("../lib/reverse-proxy-rate-limiter/conditions/subject-types").SubjectTypes;
 
 describe("Condition parameter validation tests", function () {
     it("should throw an exception because parameter is not an array", function () {
         expect(function () {
             new Condition('not an array');
-        }).to.throwException(/conditionArray parameter must be an array/);
+        }).toThrow(/conditionArray parameter must be an array/);
     });
 
     it("should throw 'invalid subject' exception", function () {
         expect(function () {
             new Condition(["invalid"]);
-        }).to.throwException(/Invalid subject: invalid/);
+        }).toThrow(/Invalid subject: invalid/);
     });
 
     it("should have a valid subject", function () {
-        var condition = new Condition(["header", "test", "eq", "test"]);
-        var subject = condition.subject;
-        expect(subject.name).to.be("header");
-        expect(subject.parameterCount).to.be(1);
-        expect(subject.predicates).to.be(SubjectTypes.header.predicates);
+        const condition = new Condition(["header", "test", "eq", "test"]);
+        const subject = condition.subject;
+        expect(subject.name).toBe("header");
+        expect(subject.parameterCount).toBe(1);
+        expect(subject.predicates).toBe(SubjectTypes.header.predicates);
     });
 
     it("should throw an exception because of wrong parameter array size", function () {
         expect(function () {
             new Condition(["header", "eq", "test"]);
-        }).to.throwException(/Expected conditionArray size is 4 but was 3/);
+        }).toThrow(/Expected conditionArray size is 4 but was 3/);
     });
 
     it("should throw an exception because of invalid predicate", function () {
         expect(function () {
             new Condition(["header", "test", "invalid predicate", "test"]);
-        }).to.throwException(/Invalid predicate: invalid predicate/);
+        }).toThrow(/Invalid predicate: invalid predicate/);
     });
 
     it("should throw an exception because of not usable predicate", function () {
         expect(function () {
             new Condition(["header", "test", "gt", "test"]);
-        }).to.throwException(/Predicate gt not usable for subject header/);
+        }).toThrow(/Predicate gt not usable for subject header/);
     });
 
     it("should be the following condition: header['testheader'] == 'test'", function () {
-        var condition = new Condition(["header", "testheader", "eq", "testvalue"]);
+        const condition = new Condition(["header", "testheader", "eq", "testvalue"]);
 
-        expect(condition.subject.name).to.be("header");
-        expect(condition.predicate).to.be(Predicates.eq);
-        expect(condition.parameters.length).to.be(1);
-        expect(condition.parameters[0]).to.be("testheader");
-        expect(condition.expectedValue).to.be("testvalue");
+        expect(condition.subject.name).toBe("header");
+        expect(condition.predicate).toBe(Predicates.eq);
+        expect(condition.parameters.length).toBe(1);
+        expect(condition.parameters[0]).toBe("testheader");
+        expect(condition.expectedValue).toBe("testvalue");
     });
 });
 
 describe("Condition evaluation tests", function () {
     it("header[test] == FIXME shoud be true", function () {
-        var condition = new Condition(["header", "test", "eq", "FIXME"]);
-        expect(condition.evaluate({headers: {test: 'FIXME'}})).to.be(true);
+        const condition = new Condition(["header", "test", "eq", "FIXME"]);
+        expect(condition.evaluate({headers: {test: 'FIXME'}})).toBe(true);
     });
 
     it("header[test] == 'some other value' should be false", function () {
-        var condition = new Condition(["header", "test", "eq", "some other value"]);
-        expect(condition.evaluate()).to.be(false);
+        const condition = new Condition(["header", "test", "eq", "some other value"]);
+        expect(condition.evaluate()).toBe(false);
     });
 
     it("client_ip == 1.2.3.4 should be true", function () {
-        var condition = new Condition(["client_ip", "eq", "1.2.3.4"]);
-        expect(condition.evaluate()).to.be(true);
+        const condition = new Condition(["client_ip", "eq", "1.2.3.4"]);
+        expect(condition.evaluate()).toBe(true);
     });
 
     it("path == '/test' should be true", function () {
-        var condition = new Condition(["path", "eq", "/test"]);
-        expect(condition.evaluate({url: "/test?a=b"})).to.be(true);
+        const condition = new Condition(["path", "eq", "/test"]);
+        expect(condition.evaluate({url: "/test?a=b"})).toBe(true);
     });
 
     it("true eq true should be true", function () {
-        var condition = new Condition(["true", "eq", "true"]);
-        expect(condition.evaluate()).to.be(true);
+        const condition = new Condition(["true", "eq", "true"]);
+        expect(condition.evaluate()).toBe(true);
     });
 
     it("simple regexp should match", function () {
-        var condition = new Condition(["header", "test", "matches", "^FIXM.$"]);
-        expect(condition.evaluate({headers: {test: 'FIXME'}})).to.be(true);
+        const condition = new Condition(["header", "test", "matches", "^FIXM.$"]);
+        expect(condition.evaluate({headers: {test: 'FIXME'}})).toBe(true);
     });
 
     it("regexp should not match 'undefined' if the header specified in condition is not present", function () {
-        var condition = new Condition(["header", "test", "matches", ".*"]);
-        expect(condition.evaluate({headers: {randomHeader: 'testValue'}})).to.be(false);
+        const condition = new Condition(["header", "test", "matches", ".*"]);
+        expect(condition.evaluate({headers: {randomHeader: 'testValue'}})).toBe(false);
     });
 
     it("simple regexp should not match", function () {
-        var condition = new Condition(["header", "test", "matches", "^FIXM.{2}$"]);
-        expect(condition.evaluate()).to.be(false);
+        const condition = new Condition(["header", "test", "matches", "^FIXM.{2}$"]);
+        expect(condition.evaluate()).toBe(false);
     });
 });

--- a/test/config-update-test.js
+++ b/test/config-update-test.js
@@ -1,19 +1,18 @@
 "use strict";
 
-var expect = require('expect.js'),
-    _ = require("lodash"),
-    assert = require('assert'),
-    helpers = require('./helpers'),
-    rateLimiter = require("../lib/reverse-proxy-rate-limiter/"),
-    LimitsEvaluator = require("../lib/reverse-proxy-rate-limiter/limits-evaluator"),
-    EventEmitter = require('events').EventEmitter,
-    createTestLimitsEvaluator = require("./helpers").createTestLimitsEvaluator,
-    TestLimitsConfigurationLoader = require("./helpers").TestLimitsConfigurationLoader;
+const expect = require('expect');
+const _ = require("lodash");
+const assert = require('assert');
+const helpers = require('./helpers');
+const LimitsEvaluator = require("../lib/reverse-proxy-rate-limiter/limits-evaluator");
+const EventEmitter = require('events').EventEmitter;
+const createTestLimitsEvaluator = require("./helpers").createTestLimitsEvaluator;
+const TestLimitsConfigurationLoader = require("./helpers").TestLimitsConfigurationLoader;
 
 describe("Initializing Ratelimiter with limitsConfiguration", function () {
-    var evaluator;
+    let evaluator;
     beforeEach(function (done) {
-        var settings = require('../lib/reverse-proxy-rate-limiter/settings').load();
+        const settings = require('../lib/reverse-proxy-rate-limiter/settings').load();
         settings.fullConfigEndpoint = "file:./test/fixtures/example_configuration.json";
 
         evaluator = new LimitsEvaluator(settings, new EventEmitter());
@@ -21,31 +20,31 @@ describe("Initializing Ratelimiter with limitsConfiguration", function () {
     });
 
     it("should load required parameters", function () {
-        expect(evaluator.limitsConfiguration.maxRequests).to.be(30);
-        expect(evaluator.limitsConfiguration.maxRequestsWithoutBuffer).to.be(27);
-        expect(evaluator.limitsConfiguration.bufferRatio).to.be(0.1);
-        expect(evaluator.limitsConfiguration.healthcheckUrl).to.be("/healthcheck/");
+        expect(evaluator.limitsConfiguration.maxRequests).toBe(30);
+        expect(evaluator.limitsConfiguration.maxRequestsWithoutBuffer).toBe(27);
+        expect(evaluator.limitsConfiguration.bufferRatio).toBe(0.1);
+        expect(evaluator.limitsConfiguration.healthcheckUrl).toBe("/healthcheck/");
     });
 
     it("should load 3 buckets", function () {
-        expect(Object.keys(evaluator.limitsConfiguration.buckets).length).to.be(3);
+        expect(Object.keys(evaluator.limitsConfiguration.buckets).length).toBe(3);
     });
 
     it("should load default bucket", function () {
-        var defaultBucket = helpers.getBucketByName(evaluator.limitsConfiguration.buckets, "default");
+        const defaultBucket = helpers.getBucketByName(evaluator.limitsConfiguration.buckets, "default");
 
-        expect(defaultBucket.name).to.be("default");
-        expect(defaultBucket.capacityUnit).to.be(7);
-        expect(defaultBucket.maxRequests).to.be(19);
-        expect(defaultBucket.maxRequestsPerIp).to.be(5);
+        expect(defaultBucket.name).toBe("default");
+        expect(defaultBucket.capacityUnit).toBe(7);
+        expect(defaultBucket.maxRequests).toBe(19);
+        expect(defaultBucket.maxRequestsPerIp).toBe(5);
     });
 
     it("should load and configure all the buckets' limits", function () {
-        expect(helpers.getBucketByName(evaluator.limitsConfiguration.buckets, "default").maxRequests).to.be(19);
-        expect(helpers.getBucketByName(evaluator.limitsConfiguration.buckets, "default").maxRequestsPerIp).to.be(5);
+        expect(helpers.getBucketByName(evaluator.limitsConfiguration.buckets, "default").maxRequests).toBe(19);
+        expect(helpers.getBucketByName(evaluator.limitsConfiguration.buckets, "default").maxRequestsPerIp).toBe(5);
 
-        expect(helpers.getBucketByName(evaluator.limitsConfiguration.buckets, "reuse").maxRequests).to.be(6);
-        expect(helpers.getBucketByName(evaluator.limitsConfiguration.buckets, "backup").maxRequests).to.be(3);
+        expect(helpers.getBucketByName(evaluator.limitsConfiguration.buckets, "reuse").maxRequests).toBe(6);
+        expect(helpers.getBucketByName(evaluator.limitsConfiguration.buckets, "backup").maxRequests).toBe(3);
     });
 
     it("should fall back to default limits configuration if loading of configuration failed", function () {
@@ -54,17 +53,17 @@ describe("Initializing Ratelimiter with limitsConfiguration", function () {
         evaluator.onConfigurationUpdated = null;
         evaluator.loadConfig();
 
-        expect(evaluator.limitsConfiguration.maxRequests).to.be(0);
-        expect(evaluator.limitsConfiguration.maxRequestsWithoutBuffer).to.be(0);
-        expect(evaluator.limitsConfiguration.bufferRatio).to.be(0);
-        expect(evaluator.limitsConfiguration.buckets.length).to.be(1);
-        expect(evaluator.limitsConfiguration.buckets[0].name).to.be("default");
+        expect(evaluator.limitsConfiguration.maxRequests).toBe(0);
+        expect(evaluator.limitsConfiguration.maxRequestsWithoutBuffer).toBe(0);
+        expect(evaluator.limitsConfiguration.bufferRatio).toBe(0);
+        expect(evaluator.limitsConfiguration.buckets.length).toBe(1);
+        expect(evaluator.limitsConfiguration.buckets[0].name).toBe("default");
     });
 });
 
 
 describe("Config change tests", function () {
-    var cfg = {
+    const cfg = {
         "version": 1,
         "max_requests": 10,
         "buffer_ratio": 0.1,
@@ -77,16 +76,16 @@ describe("Config change tests", function () {
     };
 
     function cloneConfig(cfg) {
-        return _.clone(cfg, true);
+        return _.cloneDeep(cfg);
     }
 
     function assertRequestCountsEqual(bucket, ip, expectedCounts) {
-        assert.equal(evaluator.counter.getGlobalRequestCount(), expectedCounts[0]);
-        assert.equal(evaluator.counter.getRequestCountForBucket(bucket), expectedCounts[1]);
-        assert.equal(evaluator.counter.getRequestCountForBucketAndIP(bucket, ip), expectedCounts[2]);
+        assert.strictEqual(evaluator.counter.getGlobalRequestCount(), expectedCounts[0]);
+        assert.strictEqual(evaluator.counter.getRequestCountForBucket(bucket), expectedCounts[1]);
+        assert.strictEqual(evaluator.counter.getRequestCountForBucketAndIP(bucket, ip), expectedCounts[2]);
     }
 
-    var cfgWith2Buckets = cloneConfig(cfg);
+    const cfgWith2Buckets = cloneConfig(cfg);
     cfgWith2Buckets.buckets.push({
         "name": "test",
         "conditions": [["true", "eq", "true"]],
@@ -95,7 +94,7 @@ describe("Config change tests", function () {
         }
     });
 
-    var evaluator;
+    let evaluator;
     beforeEach(function () {
         // the rateLimiter created by createTestLimitsEvaluator does not start a proxy so it doesn't need to be terminated
         evaluator = createTestLimitsEvaluator({});
@@ -103,43 +102,43 @@ describe("Config change tests", function () {
     });
 
     it("changing a bucket's config to have no limits it should have no limits", function () {
-        var cfg2 = cloneConfig(cfg);
-        cfg2.buckets[0] = {name: "default"};
-        assert.equal(evaluator.limitsConfiguration.buckets[0].capacityUnit, 2);
+        const cfg2 = cloneConfig(cfg);
+        assert.strictEqual(evaluator.limitsConfiguration.buckets[0].capacityUnit, 2);
 
+        cfg2.buckets[0] = {name: "default"};
         evaluator.updateConfig(cfg2);
-        assert.equal(evaluator.limitsConfiguration.buckets[0].capacityUnit, 0);
+        assert.strictEqual(evaluator.limitsConfiguration.buckets[0].capacityUnit, 0);
     });
 
     it("changing the bucket's config should not change the request count", function () {
 
         evaluator.counter.increment(evaluator.limitsConfiguration.buckets[0], "dummy_ip");
 
-        assert.equal(evaluator.limitsConfiguration.buckets[0].capacityUnit, 2);
-        assert.equal(assertRequestCountsEqual(evaluator.limitsConfiguration.buckets[0], "dummy_ip", [1, 1, 1]));
+        assert.strictEqual(evaluator.limitsConfiguration.buckets[0].capacityUnit, 2);
+        assertRequestCountsEqual(evaluator.limitsConfiguration.buckets[0], "dummy_ip", [1, 1, 1]);
 
-        var cfg2 = cloneConfig(cfg);
+        const cfg2 = cloneConfig(cfg);
         cfg2.buckets[0].limits.capacity_unit = 3;
         evaluator.updateConfig(cfg2);
 
-        assert.equal(evaluator.limitsConfiguration.buckets[0].capacityUnit, 3);
-        assert.deepEqual(assertRequestCountsEqual(evaluator.limitsConfiguration.buckets[0], "dummy_ip", [1, 1, 1]));
+        assert.strictEqual(evaluator.limitsConfiguration.buckets[0].capacityUnit, 3);
+        assertRequestCountsEqual(evaluator.limitsConfiguration.buckets[0], "dummy_ip", [1, 1, 1]);
     });
 
     it("adding and removing buckets", function () {
         evaluator.counter.increment(evaluator.limitsConfiguration.buckets[0], "dummy_ip");
-        assert.equal(evaluator.limitsConfiguration.buckets.length, 1);
-        assert.equal(assertRequestCountsEqual(evaluator.limitsConfiguration.buckets[0], "dummy_ip", [1, 1, 1]));
+        assert.strictEqual(evaluator.limitsConfiguration.buckets.length, 1);
+        assertRequestCountsEqual(evaluator.limitsConfiguration.buckets[0], "dummy_ip", [1, 1, 1]);
 
         evaluator.updateConfig(cfgWith2Buckets);
-        assert.equal(evaluator.limitsConfiguration.buckets.length, 2);
-        assert.equal(evaluator.limitsConfiguration.buckets[0].name, "test");
-        assert.equal(evaluator.limitsConfiguration.buckets[1].name, "default");
+        assert.strictEqual(evaluator.limitsConfiguration.buckets.length, 2);
+        assert.strictEqual(evaluator.limitsConfiguration.buckets[0].name, "test");
+        assert.strictEqual(evaluator.limitsConfiguration.buckets[1].name, "default");
 
         evaluator.updateConfig(cfg);
-        assert.equal(evaluator.limitsConfiguration.buckets.length, 1);
-        assert.equal(evaluator.limitsConfiguration.buckets[0].name, "default");
-        assert.equal(assertRequestCountsEqual(evaluator.limitsConfiguration.buckets[0], "dummy_ip", [1, 1, 1]));
+        assert.strictEqual(evaluator.limitsConfiguration.buckets.length, 1);
+        assert.strictEqual(evaluator.limitsConfiguration.buckets[0].name, "default");
+        assertRequestCountsEqual(evaluator.limitsConfiguration.buckets[0], "dummy_ip", [1, 1, 1]);
     });
 
 });

--- a/test/config-validation-test.js
+++ b/test/config-validation-test.js
@@ -1,28 +1,28 @@
 "use strict";
 
-var fs = require('fs'),
-    http = require('http'),
-    expect = require('expect.js'),
-    assert = require("assert"),
-    _ = require("lodash"),
-    limitsConfig = require("../lib/reverse-proxy-rate-limiter/limits-config"),
-    LimitsConfigurationLoader = require("../lib/reverse-proxy-rate-limiter/limits-config").LimitsConfigurationLoader,
-    schema = require("../lib/reverse-proxy-rate-limiter/limits-config-schema");
+const fs = require('fs');
+const http = require('http');
+const expect = require('expect');
+const assert = require("assert");
+const _ = require("lodash");
+const limitsConfig = require("../lib/reverse-proxy-rate-limiter/limits-config");
+const LimitsConfigurationLoader = require("../lib/reverse-proxy-rate-limiter/limits-config").LimitsConfigurationLoader;
+const schema = require("../lib/reverse-proxy-rate-limiter/limits-config-schema");
 
 describe("Schema validator", function () {
     it("should accept valid config", function () {
-        var validConfig = {"version": 1, "max_requests": 10, "buffer_ratio": 0.1, "buckets": [{"name": "default"}]};
-        expect(limitsConfig.isValidConfig(validConfig)).to.be.ok();
+        const validConfig = {"version": 1, "max_requests": 10, "buffer_ratio": 0.1, "buckets": [{"name": "default"}]};
+        expect(limitsConfig.isValidConfig(validConfig)).toBeTruthy();
     });
 
     it("should reject invalid config'", function () {
-        var invalidConfig = {"version": "a", "max_requests": -1, "buffer_ratio": 2};
-        expect(limitsConfig.isValidConfig(invalidConfig)).to.not.be.ok();
+        const invalidConfig = {"version": "a", "max_requests": -1, "buffer_ratio": 2};
+        expect(limitsConfig.isValidConfig(invalidConfig)).toBeFalsy();
     });
 });
 
 describe("Conditions", function () {
-    var configWithValidCondition = {
+    const configWithValidCondition = {
         "version": 1,
         "max_requests": 10,
         "buffer_ratio": 0.1,
@@ -41,32 +41,32 @@ describe("Conditions", function () {
     };
 
     it("should be accepted with valid parameters", function () {
-        expect(schema.validate(configWithValidCondition).valid).to.be.ok();
+        expect(schema.validate(configWithValidCondition).valid).toBeTruthy();
     });
 
     it("should be rejected with invalid subject type", function () {
-        var configWithInvalidSubjectType = configWithValidCondition;
+        const configWithInvalidSubjectType = configWithValidCondition;
         configWithInvalidSubjectType.buckets[0].conditions = [
             ["unsupported_subject_type", "X-Prezi-Client", "eq", "reuse"]
         ];
 
-        var result = schema.validate(configWithInvalidSubjectType);
+        const result = schema.validate(configWithInvalidSubjectType);
 
-        expect(result.valid).to.not.be.ok();
+        expect(result.valid).toBeFalsy();
         expect(_.find(result.errors, function (error) {
             return error.message.indexOf("Invalid subject") > -1;
         }));
     });
 
     it("should be rejected with invalid predicate", function () {
-        var configWithInvalidPredicate = configWithValidCondition;
+        const configWithInvalidPredicate = configWithValidCondition;
         configWithInvalidPredicate.buckets[0].conditions = [
             ["header", "X-Prezi-Client", "equals_not_eq", "reuse"]
         ];
 
-        var result = schema.validate(configWithInvalidPredicate);
+        const result = schema.validate(configWithInvalidPredicate);
 
-        expect(result.valid).to.not.be.ok();
+        expect(result.valid).toBeFalsy();
         expect(_.find(result.errors, function (error) {
             return error.message.indexOf("Invalid predicate") > -1;
         }));
@@ -74,10 +74,10 @@ describe("Conditions", function () {
 });
 
 describe("Load config from url", function () {
-    var httpServer;
-    before(function () {
+    let httpServer;
+    before(function (done) {
         httpServer = http.createServer(function (req, res) {
-            var cfg;
+            let cfg;
             if (req.url === "/valid-config/") {
                 cfg = fs.readFileSync(__dirname + "/fixtures/example_configuration.json");
             } else if (req.url === "/invalid-config/") {
@@ -97,7 +97,7 @@ describe("Load config from url", function () {
             res.writeHead(200, {'Content-Type': 'text/plain'});
             res.write(cfg);
             res.end();
-        }).listen(9999);
+        }).listen(9999, done);
     });
 
     after(function (done) {
@@ -105,35 +105,35 @@ describe("Load config from url", function () {
     });
 
     it("should load valid config", function (done) {
-        var limitsConfigurationLoader = new LimitsConfigurationLoader("http://localhost:9999/valid-config/");
+        const limitsConfigurationLoader = new LimitsConfigurationLoader("http://localhost:9999/valid-config/");
         limitsConfigurationLoader.load(function (cfg) {
-            assert.equal(cfg.version, 1);
-            assert.equal(cfg.max_requests, 30);
-            assert.equal(cfg.buckets.length, 3);
+            assert.strictEqual(cfg.version, 1);
+            assert.strictEqual(cfg.max_requests, 30);
+            assert.strictEqual(cfg.buckets.length, 3);
             done();
         });
     });
 
     it("should handle invalid config", function (done) {
-        var limitsConfigurationLoader = new LimitsConfigurationLoader("http://localhost:9999/invalid-config/");
+        const limitsConfigurationLoader = new LimitsConfigurationLoader("http://localhost:9999/invalid-config/");
         limitsConfigurationLoader.load(function (cfg) {
-            assert.equal(cfg, null);
+            assert.strictEqual(cfg, null);
             done();
         });
     });
 
     it("should handle 404 not found", function (done) {
-        var limitsConfigurationLoader = new LimitsConfigurationLoader("http://localhost:9999/404");
+        const limitsConfigurationLoader = new LimitsConfigurationLoader("http://localhost:9999/404");
         limitsConfigurationLoader.load(function (cfg) {
-            assert.equal(cfg, null);
+            assert.strictEqual(cfg, null);
             done();
         });
     });
 
     it("should handle 500 internal server error", function (done) {
-        var limitsConfigurationLoader = new LimitsConfigurationLoader("http://localhost:9999/500");
+        const limitsConfigurationLoader = new LimitsConfigurationLoader("http://localhost:9999/500");
         limitsConfigurationLoader.load(function (cfg) {
-            assert.equal(cfg, null);
+            assert.strictEqual(cfg, null);
             done();
         });
     });

--- a/test/counterstore-test.js
+++ b/test/counterstore-test.js
@@ -1,15 +1,15 @@
 "use strict";
 
-var assert = require("assert"),
+const assert = require("assert"),
     CounterStore = require("../lib/reverse-proxy-rate-limiter/counter.js").CounterStore;
 
 describe("CounterStore tests", function () {
-    var cs;
+    let cs;
     beforeEach(function () {
         cs = new CounterStore();
     });
 
-    var bucket1 = {name: "bucket1"}, bucket2 = {name: "bucket2"};
+    const bucket1 = {name: "bucket1"}, bucket2 = {name: "bucket2"};
 
     it("should increment the counters", function () {
         cs.increment(bucket1, "ip1");
@@ -17,7 +17,7 @@ describe("CounterStore tests", function () {
         cs.increment(bucket1, "ip2");
         cs.increment(bucket2, "ip1");
 
-        var counters = {
+        const counters = {
             global: cs.getGlobalRequestCount(),
 
             bucket1: cs.getRequestCountForBucket(bucket1, "ip1"),
@@ -29,14 +29,14 @@ describe("CounterStore tests", function () {
             bucket2_ip2: cs.getRequestCountForBucketAndIP(bucket2, "ip2")
         };
 
-        assert.equal(counters.global, 4);
-        assert.equal(counters.bucket1, 3);
-        assert.equal(counters.bucket1_ip1, 2);
-        assert.equal(counters.bucket1_ip2, 1);
+        assert.strictEqual(counters.global, 4);
+        assert.strictEqual(counters.bucket1, 3);
+        assert.strictEqual(counters.bucket1_ip1, 2);
+        assert.strictEqual(counters.bucket1_ip2, 1);
 
-        assert.equal(counters.bucket2, 1);
-        assert.equal(counters.bucket2_ip1, 1);
-        assert.equal(counters.bucket2_ip2, 0);
+        assert.strictEqual(counters.bucket2, 1);
+        assert.strictEqual(counters.bucket2_ip1, 1);
+        assert.strictEqual(counters.bucket2_ip2, 0);
     });
 
     it("should increment and decrement the counters", function () {
@@ -47,7 +47,7 @@ describe("CounterStore tests", function () {
         cs.decrement(bucket1, "ip1");
         cs.decrement(bucket1, "ip2");
 
-        var counters = {
+        const counters = {
             global: cs.getGlobalRequestCount(),
 
             bucket1: cs.getRequestCountForBucket(bucket1),
@@ -55,15 +55,15 @@ describe("CounterStore tests", function () {
             bucket1_ip2: cs.getRequestCountForBucketAndIP(bucket1, "ip2")
         };
 
-        assert.equal(counters.global, 1);
-        assert.equal(counters.bucket1, 1);
-        assert.equal(counters.bucket1_ip1, 1);
-        assert.equal(counters.bucket1_ip2, 0);
+        assert.strictEqual(counters.global, 1);
+        assert.strictEqual(counters.bucket1, 1);
+        assert.strictEqual(counters.bucket1_ip1, 1);
+        assert.strictEqual(counters.bucket1_ip2, 0);
     });
 
     it("should delete the nulled values", function () {
         cs.increment(bucket1, "ip1");
         cs.decrement(bucket1, "ip1");
-        assert.equal(Object.keys(cs.counters).length, 0);
+        assert.strictEqual(Object.keys(cs.counters).length, 0);
     });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var limitsConfigurationLoader = require("../lib/reverse-proxy-rate-limiter/limits-config").LimitsConfigurationLoader;
+const LimitsConfigurationLoader = require("../lib/reverse-proxy-rate-limiter/limits-config").LimitsConfigurationLoader;
 
 module.exports.createTestLimitsEvaluator = createTestLimitsEvaluator;
 module.exports.getBucketByName = getBucketByName;
@@ -8,16 +8,16 @@ module.exports.TestLimitsConfigurationLoader = TestLimitsConfigurationLoader;
 
 
 function createTestLimitsEvaluator(settings) {
-    var evaluator = require("../lib/reverse-proxy-rate-limiter/limits-evaluator");
+    const Evaluator = require("../lib/reverse-proxy-rate-limiter/limits-evaluator");
     // returns a RateLimiter instance that neither initializes a config nor starts the proxy
 
-    var EventEmitter = require('events').EventEmitter;
+    const EventEmitter = require('events').EventEmitter;
 
     function TestLimitsEvaluator(settings) {
-        evaluator.call(this, settings, new EventEmitter());
+        Evaluator.call(this, settings, new EventEmitter());
     }
 
-    TestLimitsEvaluator.prototype = Object.create(evaluator.prototype);
+    TestLimitsEvaluator.prototype = Object.create(Evaluator.prototype);
     TestLimitsEvaluator.prototype.loadConfig = function () {
     };
     TestLimitsEvaluator.prototype.initProxy = function () {
@@ -29,14 +29,14 @@ function createTestLimitsEvaluator(settings) {
 function TestLimitsConfigurationLoader(fullConfigEndpoint) {
 
     function TestLimitsConfigurationLoader(settings) {
-        limitsConfigurationLoader.call(this, fullConfigEndpoint);
+        LimitsConfigurationLoader.call(this, fullConfigEndpoint);
     }
 }
 
-TestLimitsConfigurationLoader.prototype = Object.create(limitsConfigurationLoader.prototype);
+TestLimitsConfigurationLoader.prototype = Object.create(LimitsConfigurationLoader.prototype);
 TestLimitsConfigurationLoader.prototype.load = function (callback) { callback(null); };
 
 function getBucketByName(buckets, name) {
-    var filteredBuckets = buckets.filter(function (bucket) { return bucket.name == name});
+    const filteredBuckets = buckets.filter(function (bucket) { return bucket.name == name});
     return filteredBuckets[0];
 }

--- a/test/integration/complex-limit-tests.js
+++ b/test/integration/complex-limit-tests.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var itUtils = require('./integration-utils');
+const itUtils = require('./integration-utils');
 
 itUtils.describe("Integration tests", function(tester) {
 
-    var cfg2 = {
+    const cfg2 = {
         version: 1,
         max_requests: 10,
         buffer_ratio: 0.2,
@@ -31,10 +31,10 @@ itUtils.describe("Integration tests", function(tester) {
             ]
         }]
     };
-    var bucketReuse = {
+    const bucketReuse = {
         "bucket": "reuse"
     };
-    var bucketBackup = {
+    const bucketBackup = {
         "bucket": "backup"
     };
 
@@ -82,7 +82,7 @@ itUtils.describe("Integration tests", function(tester) {
         });
     });
 
-    var maxRequestsPerIPConfig = {
+    const maxRequestsPerIPConfig = {
         version: 1,
         max_requests: 10,
         buffer_ratio: 0.2,
@@ -93,7 +93,7 @@ itUtils.describe("Integration tests", function(tester) {
             }
         }]
     };
-    var bucketDefault = {
+    const bucketDefault = {
         "bucket": "default"
     };
 

--- a/test/integration/counter-test.js
+++ b/test/integration/counter-test.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var assert = require("assert"),
+const assert = require("assert"),
     helpers = require("./../helpers"),
-	itUtils = require('./integration-utils');
+    itUtils = require('./integration-utils');
 
 itUtils.describe("counter consistency test", function(tester) {
-    var cfg = {
+    const cfg = {
         version: 1,
         max_requests: 3,
         buffer_ratio: 0,
@@ -28,19 +28,19 @@ itUtils.describe("counter consistency test", function(tester) {
     });
 
     function getCountForBucket(ratelimiter, bucketName) {
-        var bucket = helpers.getBucketByName(tester.rateLimiter.evaluator.limitsConfiguration.buckets, bucketName);
+        const bucket = helpers.getBucketByName(tester.rateLimiter.evaluator.limitsConfiguration.buckets, bucketName);
         return ratelimiter.evaluator.counter.getRequestCountForBucket(bucket);
     }
 
     it("counter consistency: two in, two served", function (done) {
         tester.sendRequests(2, {}, function () {
-            assert.equal(2, tester.pendingRequestsCount());
-            assert.equal(2, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-            assert.equal(2, getCountForBucket(tester.rateLimiter, "default"));
+            assert.strictEqual(2, tester.pendingRequestsCount());
+            assert.strictEqual(2, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+            assert.strictEqual(2, getCountForBucket(tester.rateLimiter, "default"));
             tester.serveRequests().onServed(function () {
-                assert.equal(0, tester.pendingRequestsCount());
-                assert.equal(0, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-                assert.equal(0, getCountForBucket(tester.rateLimiter, "default"));
+                assert.strictEqual(0, tester.pendingRequestsCount());
+                assert.strictEqual(0, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+                assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "default"));
                 done();
             });
         });
@@ -48,18 +48,18 @@ itUtils.describe("counter consistency test", function(tester) {
 
     it("counter consistency: four in, one rejected, three served", function (done) {
         tester.sendRequests(3, {}, function () {
-            assert.equal(3, tester.pendingRequestsCount());
-            assert.equal(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-            assert.equal(3, getCountForBucket(tester.rateLimiter, "default"));
+            assert.strictEqual(3, tester.pendingRequestsCount());
+            assert.strictEqual(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+            assert.strictEqual(3, getCountForBucket(tester.rateLimiter, "default"));
 
             tester.sendRequest().onRejected(function () {
-                assert.equal(3, tester.pendingRequestsCount());
-                assert.equal(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-                assert.equal(3, getCountForBucket(tester.rateLimiter, "default"));
+                assert.strictEqual(3, tester.pendingRequestsCount());
+                assert.strictEqual(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+                assert.strictEqual(3, getCountForBucket(tester.rateLimiter, "default"));
                 tester.serveRequests().onServed(function () {
-                    assert.equal(0, tester.pendingRequestsCount());
-                    assert.equal(0, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-                    assert.equal(0, getCountForBucket(tester.rateLimiter, "default"));
+                    assert.strictEqual(0, tester.pendingRequestsCount());
+                    assert.strictEqual(0, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+                    assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "default"));
                     done();
                 });
             });
@@ -68,22 +68,22 @@ itUtils.describe("counter consistency test", function(tester) {
 
     it("counter consistency: one default bucket, one A bucket, both served", function (done) {
         tester.sendRequest().onForwarded(function () {
-            assert.equal(1, tester.pendingRequestsCount());
-            assert.equal(1, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-            assert.equal(1, getCountForBucket(tester.rateLimiter, "default"));
-            assert.equal(0, getCountForBucket(tester.rateLimiter, "A"));
+            assert.strictEqual(1, tester.pendingRequestsCount());
+            assert.strictEqual(1, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+            assert.strictEqual(1, getCountForBucket(tester.rateLimiter, "default"));
+            assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "A"));
 
             tester.sendRequest({bucket: 'A'}).onForwarded(function () {
-                assert.equal(2, tester.pendingRequestsCount());
-                assert.equal(2, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-                assert.equal(1, getCountForBucket(tester.rateLimiter, "default"));
-                assert.equal(1, getCountForBucket(tester.rateLimiter, "A"));
+                assert.strictEqual(2, tester.pendingRequestsCount());
+                assert.strictEqual(2, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+                assert.strictEqual(1, getCountForBucket(tester.rateLimiter, "default"));
+                assert.strictEqual(1, getCountForBucket(tester.rateLimiter, "A"));
 
                 tester.serveRequests().onServed(function () {
-                    assert.equal(0, tester.pendingRequestsCount());
-                    assert.equal(0, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-                    assert.equal(0, getCountForBucket(tester.rateLimiter, "default"));
-                    assert.equal(0, getCountForBucket(tester.rateLimiter, "A"));
+                    assert.strictEqual(0, tester.pendingRequestsCount());
+                    assert.strictEqual(0, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+                    assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "default"));
+                    assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "A"));
                     done();
                 });
             });
@@ -92,28 +92,28 @@ itUtils.describe("counter consistency test", function(tester) {
 
     it("counter consistency: one A, two default, one rejected due to global limit", function (done) {
         tester.sendRequest({bucket: 'A'}).onForwarded(function () {
-            assert.equal(1, tester.pendingRequestsCount());
-            assert.equal(1, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-            assert.equal(0, getCountForBucket(tester.rateLimiter, "default"));
-            assert.equal(1, getCountForBucket(tester.rateLimiter, "A"));
+            assert.strictEqual(1, tester.pendingRequestsCount());
+            assert.strictEqual(1, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+            assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "default"));
+            assert.strictEqual(1, getCountForBucket(tester.rateLimiter, "A"));
 
             tester.sendRequests(2, {}, function () {
-                assert.equal(3, tester.pendingRequestsCount());
-                assert.equal(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-                assert.equal(2, getCountForBucket(tester.rateLimiter, "default"));
-                assert.equal(1, getCountForBucket(tester.rateLimiter, "A"));
+                assert.strictEqual(3, tester.pendingRequestsCount());
+                assert.strictEqual(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+                assert.strictEqual(2, getCountForBucket(tester.rateLimiter, "default"));
+                assert.strictEqual(1, getCountForBucket(tester.rateLimiter, "A"));
 
                 tester.sendRequest().onRejected(function () {
-                    assert.equal(3, tester.pendingRequestsCount());
-                    assert.equal(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-                    assert.equal(2, getCountForBucket(tester.rateLimiter, "default"));
-                    assert.equal(1, getCountForBucket(tester.rateLimiter, "A"));
+                    assert.strictEqual(3, tester.pendingRequestsCount());
+                    assert.strictEqual(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+                    assert.strictEqual(2, getCountForBucket(tester.rateLimiter, "default"));
+                    assert.strictEqual(1, getCountForBucket(tester.rateLimiter, "A"));
 
                     tester.serveRequests().onServed(function () {
-                        assert.equal(0, tester.pendingRequestsCount());
-                        assert.equal(0, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-                        assert.equal(0, getCountForBucket(tester.rateLimiter, "default"));
-                        assert.equal(0, getCountForBucket(tester.rateLimiter, "A"));
+                        assert.strictEqual(0, tester.pendingRequestsCount());
+                        assert.strictEqual(0, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+                        assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "default"));
+                        assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "A"));
                         done();
                     });
                 });
@@ -123,22 +123,22 @@ itUtils.describe("counter consistency test", function(tester) {
 
     it("counter consistency: three A, one rejected due to global limit", function (done) {
         tester.sendRequests(3, {bucket: 'A'}, function () {
-            assert.equal(3, tester.pendingRequestsCount());
-            assert.equal(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-            assert.equal(0, getCountForBucket(tester.rateLimiter, "default"));
-            assert.equal(3, getCountForBucket(tester.rateLimiter, "A"));
+            assert.strictEqual(3, tester.pendingRequestsCount());
+            assert.strictEqual(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+            assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "default"));
+            assert.strictEqual(3, getCountForBucket(tester.rateLimiter, "A"));
 
             tester.sendRequest({bucket: "A"}).onRejected(function () {
-                assert.equal(3, tester.pendingRequestsCount());
-                assert.equal(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-                assert.equal(0, getCountForBucket(tester.rateLimiter, "default"));
-                assert.equal(3, getCountForBucket(tester.rateLimiter, "A"));
+                assert.strictEqual(3, tester.pendingRequestsCount());
+                assert.strictEqual(3, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+                assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "default"));
+                assert.strictEqual(3, getCountForBucket(tester.rateLimiter, "A"));
 
                 tester.serveRequests().onServed(function () {
-                    assert.equal(0, tester.pendingRequestsCount());
-                    assert.equal(0, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
-                    assert.equal(0, getCountForBucket(tester.rateLimiter, "default"));
-                    assert.equal(0, getCountForBucket(tester.rateLimiter, "A"));
+                    assert.strictEqual(0, tester.pendingRequestsCount());
+                    assert.strictEqual(0, tester.rateLimiter.evaluator.counter.getGlobalRequestCount());
+                    assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "default"));
+                    assert.strictEqual(0, getCountForBucket(tester.rateLimiter, "A"));
                     done();
                 });
             });

--- a/test/integration/error-tests.js
+++ b/test/integration/error-tests.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var assert = require("assert"),
+const assert = require("assert"),
     itUtils = require('./integration-utils');
 
 itUtils.describe("Integration tests - error-tests", function (tester) {
@@ -13,9 +13,9 @@ itUtils.describe("Integration tests - error-tests", function (tester) {
         changeConfig("max_requests", 1);
 
         tester.sendRequest().onForwarded(function () {
-            assert.equal(tester.rateLimiter.evaluator.counter.getGlobalRequestCount(), 1);
+            assert.strictEqual(tester.rateLimiter.evaluator.counter.getGlobalRequestCount(), 1);
             tester.failRequestWithInvalidContentLength().onFailed(function () {
-                assert.equal(tester.rateLimiter.evaluator.counter.getGlobalRequestCount(), 0);
+                assert.strictEqual(tester.rateLimiter.evaluator.counter.getGlobalRequestCount(), 0);
                 done();
             });
         });

--- a/test/integration/eventhook-test.js
+++ b/test/integration/eventhook-test.js
@@ -1,20 +1,19 @@
 "use strict";
 
-var limitsConfig = require("../../lib/reverse-proxy-rate-limiter/limits-config"),
-    assert = require("assert"),
-    http = require("http"),
-    itUtils = require('./integration-utils');
+const limitsConfig = require("../../lib/reverse-proxy-rate-limiter/limits-config");
+const assert = require("assert");
+const itUtils = require('./integration-utils');
 
 itUtils.describe("Integration tests - from the hooks", function(tester) {
 
-    var eventStat = bindEventHandlers(tester.rateLimiter.proxyEvent);
+    const eventStat = bindEventHandlers(tester.rateLimiter.proxyEvent);
 
     function bindEventHandlers(proxyEvent) {
-        var eventStat = {};
+        const eventStat = {};
 
-        var e = function(name) {
-            return function() {
-                var v = eventStat[name] != undefined ? eventStat[name] : 0;
+        const e = function (name) {
+            return function () {
+                const v = eventStat[name] != undefined ? eventStat[name] : 0;
                 eventStat[name] = v + 1;
             }
         };
@@ -53,7 +52,7 @@ itUtils.describe("Integration tests - from the hooks", function(tester) {
 
         tester.sendRequest().onForwarded(function() {
             tester.serveRequests(1).onServed(function() {
-                assert.equal(eventStat['served'], 1);
+                assert.strictEqual(eventStat['served'], 1);
                 done();
             });
         });
@@ -63,7 +62,7 @@ itUtils.describe("Integration tests - from the hooks", function(tester) {
         clearEventStat(eventStat);
 
         tester.sendRequest().onForwarded(function() {
-            assert.equal(eventStat['forwarded'], 1);
+            assert.strictEqual(eventStat['forwarded'], 1);
             done();
         });
     });
@@ -73,10 +72,10 @@ itUtils.describe("Integration tests - from the hooks", function(tester) {
         changeConfig("max_requests", 1);
 
         tester.sendRequest().onForwarded(function() {
-            assert.equal(eventStat['forwarded'], 1);
+            assert.strictEqual(eventStat['forwarded'], 1);
             tester.sendRequest().onRejected(function() {
-                assert.equal(eventStat['forwarded'], 1);
-                assert.equal(eventStat['rejected'], 1);
+                assert.strictEqual(eventStat['forwarded'], 1);
+                assert.strictEqual(eventStat['rejected'], 1);
                 done();
             });
         });
@@ -89,13 +88,13 @@ itUtils.describe("Integration tests - from the hooks", function(tester) {
         tester.sendRequest().onForwarded(function() {
             assert(eventStat['forwarded'], 1);
             tester.sendRequest().onRejected(function(response) {
-                assert.equal(eventStat['forwarded'], 1);
-                assert.equal(eventStat['rejected'], 1);
-                assert.equal(response.statusCode, 404);
-                assert.equal(JSON.parse(response.body).code, 429)
+                assert.strictEqual(eventStat['forwarded'], 1);
+                assert.strictEqual(eventStat['rejected'], 1);
+                assert.strictEqual(response.statusCode, 404);
+                assert.strictEqual(JSON.parse(response.body).code, 429);
                 tester.serveRequests(1).onServed(function() {
-                    assert.equal(eventStat['forwarded'], 1);
-                    assert.equal(eventStat['rejected'], 1);
+                    assert.strictEqual(eventStat['forwarded'], 1);
+                    assert.strictEqual(eventStat['rejected'], 1);
                     done();
                 })
             });
@@ -107,8 +106,8 @@ itUtils.describe("Integration tests - from the hooks", function(tester) {
 
         tester.sendRequest().onForwarded(function() {
             tester.failRequestWithInvalidContentLength().onFailed(function() {
-                assert.equal(eventStat['forwarded'], 1);
-                assert.equal(eventStat['failed'], 1);
+                assert.strictEqual(eventStat['forwarded'], 1);
+                assert.strictEqual(eventStat['failed'], 1);
                 done();
             });
         });

--- a/test/integration/healthcheck-test.js
+++ b/test/integration/healthcheck-test.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var request = require("request"),
-    assert = require("assert"),
-	itUtils = require('./integration-utils');
+const request = require("request");
+const assert = require("assert");
+const itUtils = require('./integration-utils');
 
 itUtils.describe("Healthcheck test", function(tester) {
 
@@ -14,7 +14,7 @@ itUtils.describe("Healthcheck test", function(tester) {
             }
         }, function (error, response, body) {
             if (!error && response.statusCode === 200) {
-                assert.equal(body, "OK");
+                assert.strictEqual(body, "OK");
                 done();
             }
         });

--- a/test/integration/integration-utils.js
+++ b/test/integration/integration-utils.js
@@ -1,8 +1,8 @@
-var IntegrationTester = require("./integration-tester").IntegrationTester,
+const IntegrationTester = require("./integration-tester").IntegrationTester,
     _ = require("lodash"),
     assert = require("assert");
 
-var cfg = {
+const cfg = {
     "version": 1,
     "max_requests": 10,
     "healthcheck_url": "/healthcheck/",
@@ -13,7 +13,7 @@ var cfg = {
 };
 
 module.exports.changeConfig = function(tester, key, value) {
-    var _cfg = _.clone(cfg, true);
+    const _cfg = _.cloneDeep(cfg);
     _cfg[key] = value;
     tester.rateLimiter.evaluator.updateConfig(_cfg);
 };
@@ -22,7 +22,7 @@ module.exports.describe = function(name, testingFunction) {
 
     describe(name, function() {
 
-        var tester = new IntegrationTester();
+        const tester = new IntegrationTester();
 
         after(function(done) {
             tester.closeTestBackendServer(function() {
@@ -47,5 +47,5 @@ module.exports.describe = function(name, testingFunction) {
 };
 
 module.exports.checkPendingRequestsCount = function(tester, expectedRequestsCount) {
-    assert.equal(tester.pendingRequestsCount(), expectedRequestsCount);
+    assert.strictEqual(tester.pendingRequestsCount(), expectedRequestsCount);
 };

--- a/test/integration/simple-limit-tests.js
+++ b/test/integration/simple-limit-tests.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var limitsConfig = require("../../lib/reverse-proxy-rate-limiter/limits-config"),
+const limitsConfig = require("../../lib/reverse-proxy-rate-limiter/limits-config"),
     itUtils = require('./integration-utils');
 
 itUtils.describe("Integration tests", function(tester) {
@@ -10,7 +10,7 @@ itUtils.describe("Integration tests", function(tester) {
     }
 
     it("should limit per bucket", function(done) {
-        var buckets = [{
+        const buckets = [{
             "name": "default"
         }, {
             "name": "A",
@@ -24,7 +24,7 @@ itUtils.describe("Integration tests", function(tester) {
 
         changeConfig("buckets", buckets);
         changeConfig("max_requests", 2);
-        var options = {
+        const options = {
             "bucket": "A"
         };
         tester.sendRequests(2, options, function() {
@@ -35,7 +35,7 @@ itUtils.describe("Integration tests", function(tester) {
     });
 
     it("should update bucket limits when requests are served", function(done) {
-        var buckets = [{
+        const buckets = [{
             "name": "default"
         }, {
             "name": "A",
@@ -49,7 +49,7 @@ itUtils.describe("Integration tests", function(tester) {
 
         changeConfig("buckets", buckets);
         changeConfig("max_requests", 2);
-        var options = {
+        const options = {
             "bucket": "A"
         };
         tester.sendRequests(2, options, function() {

--- a/test/integration/simple-tests.js
+++ b/test/integration/simple-tests.js
@@ -1,7 +1,7 @@
 "use strict";
 
-var assert = require("assert"),
-    itUtils = require('./integration-utils');
+const assert = require("assert");
+const itUtils = require('./integration-utils');
 
 itUtils.describe("Integration tests - simple tests", function(tester) {
 
@@ -73,7 +73,7 @@ itUtils.describe("Integration tests - simple tests", function(tester) {
                 tester.sendRequest({
                     "path": "healthcheck/"
                 }).onForwarded(function() {
-                    assert.equal(tester.rateLimiter.evaluator.counter.getGlobalRequestCount(), 1);
+                    assert.strictEqual(tester.rateLimiter.evaluator.counter.getGlobalRequestCount(), 1);
                     done();
                 });
             });
@@ -81,15 +81,15 @@ itUtils.describe("Integration tests - simple tests", function(tester) {
     });
 
     it("should not proxy requests to the configEndpoint", function(done) {
-        var oldEndpoint = tester.rateLimiter.settings.fullConfigEndpoint;
-        var testEndpoint = "test-config-endpoint";
+        const oldEndpoint = tester.rateLimiter.settings.fullConfigEndpoint;
+        const testEndpoint = "test-config-endpoint";
         tester.rateLimiter.settings.fullConfigEndpoint = "/" + testEndpoint;
 
         tester.sendRequest({
             "path": testEndpoint
         }).onRejected(function(res) {
 	        itUtils.checkPendingRequestsCount(tester, 0);
-            assert.equal(res.statusCode, 404);
+            assert.strictEqual(res.statusCode, 404);
 
             tester.rateLimiter.settings.fullConfigEndpoint = oldEndpoint;
             done();

--- a/test/ipextractor-test.js
+++ b/test/ipextractor-test.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var IPExtractor = require("../lib/reverse-proxy-rate-limiter/ipextractor").IPExtractor;
-var assert = require('assert');
+const IPExtractor = require("../lib/reverse-proxy-rate-limiter/ipextractor").IPExtractor;
+const assert = require('assert');
 
 describe("IP Extracting",function(){
 
-    var ipextractor;
+    let ipextractor;
     beforeEach(function(){
 
         ipextractor = new IPExtractor({
@@ -22,28 +22,28 @@ describe("IP Extracting",function(){
 
 
     it("should return the only ip", function () {
-        var result = ipextractor.extractClientIP('41.168.1.1');
-        assert.equal(result,'41.168.1.1');
+        const result = ipextractor.extractClientIP('41.168.1.1');
+        assert.strictEqual(result,'41.168.1.1');
     });
 
     it("should return the last ip", function () {
-        var result = ipextractor.extractClientIP(' 41.168.1.1, 41.168.1.2 ');
-        assert.equal(result,'41.168.1.2');
+        const result = ipextractor.extractClientIP(' 41.168.1.1, 41.168.1.2 ');
+        assert.strictEqual(result,'41.168.1.2');
     });
 
     it("should return last not ignored ip", function () {
-        var result = ipextractor.extractClientIP(' 41.168.1.1, 192.168.1.2');
-        assert.equal(result,'41.168.1.1');
+        const result = ipextractor.extractClientIP(' 41.168.1.1, 192.168.1.2');
+        assert.strictEqual(result,'41.168.1.1');
     });
 
     it("should return the last ip if no configuration", function () {
         ipextractor = new IPExtractor({});
-        var result = ipextractor.extractClientIP(' 41.168.1.1, 192.168.1.2');
-        assert.equal(result,'192.168.1.2');
+        const result = ipextractor.extractClientIP(' 41.168.1.1, 192.168.1.2');
+        assert.strictEqual(result,'192.168.1.2');
     });
 
     it("should return the last ip if no public ip present", function () {
-        var result = ipextractor.extractClientIP(' 192.168.1.1, 192.168.1.2');
-        assert.equal(result,'192.168.1.2');
+        const result = ipextractor.extractClientIP(' 192.168.1.1, 192.168.1.2');
+        assert.strictEqual(result,'192.168.1.2');
     });
 });

--- a/test/ipresolver-test.js
+++ b/test/ipresolver-test.js
@@ -1,16 +1,16 @@
 "use strict";
 
-var http = require('http'),
-    assert = require('assert'),
-    helpers = require('./helpers'),
-    ipResolver = require('../lib/reverse-proxy-rate-limiter/ipresolver');
+const http = require('http');
+const assert = require('assert');
+const helpers = require('./helpers');
+const ipResolver = require('../lib/reverse-proxy-rate-limiter/ipresolver');
 
-var EXPECTED = "expected";
-var ACTUAL = "actual";
-var HOST = "localhost";
-var PORT = "9876";
+const EXPECTED = "expected";
+const ACTUAL = "actual";
+const HOST = "localhost";
+const PORT = "9876";
 
-var TEST_FORWARD_HEADERS = {
+const TEST_FORWARD_HEADERS = {
     "X-TEST-FORWARDED-FOR": {
         "ignored_ip_ranges": [
             "127.0.0.0/8",
@@ -22,41 +22,41 @@ var TEST_FORWARD_HEADERS = {
     }
 };
 
-var TEST_FORWARD_HEADER = 'X-TEST-FORWARDED-FOR';
+const TEST_FORWARD_HEADER = 'X-TEST-FORWARDED-FOR';
 
-var CLIENT_IP = "12.34.56.78";
-var LOCAL_HOST = "127.0.0.1";
-var SOME_IP = "11.22.33.44";
-var IP_LIST = CLIENT_IP + ", " + LOCAL_HOST;
-var LONG_IP_LIST = SOME_IP + " ," + IP_LIST;
+const CLIENT_IP = "12.34.56.78";
+const LOCAL_HOST = "127.0.0.1";
+const SOME_IP = "11.22.33.44";
+const IP_LIST = CLIENT_IP + ", " + LOCAL_HOST;
+const LONG_IP_LIST = SOME_IP + " ," + IP_LIST;
 
 function createRequest(headers, expected, done) {
     headers[EXPECTED] = expected;
-    var options = {
+    const options = {
         hostname: HOST,
         path: '/',
         port: PORT,
         headers: headers
     };
-    var req = http.request(options, function (response) {
-        assert.equal(response.headers[ACTUAL], expected);
+    const req = http.request(options, function (response) {
+        assert.strictEqual(response.headers[ACTUAL], expected);
         done();
     });
     req.end();
 }
 
 describe("Client IP tests", function () {
-    var headers;
-    var httpServer;
+    let headers;
+    let httpServer;
 
-    before(function () {
+    before(function (done) {
         httpServer = http.createServer(function (req, res) {
-            var ip = new ipResolver.IPResolver(TEST_FORWARD_HEADERS).resolve(req);
+            const ip = new ipResolver.IPResolver(TEST_FORWARD_HEADERS).resolve(req);
             res.setHeader(ACTUAL, ip);
             res.setHeader("Connection", "close");
             res.writeHead(200, {'Content-Type': 'text/plain'});
             res.end();
-        }).listen(PORT, HOST);
+        }).listen(PORT, HOST, done);
     });
 
     after(function (done) {

--- a/test/rate-limiter-test.js
+++ b/test/rate-limiter-test.js
@@ -1,61 +1,61 @@
 "use strict";
 
-var expect = require('expect.js'),
+const expect = require('expect'),
     assert = require('assert'),
     rateLimiter = require("../lib/reverse-proxy-rate-limiter/"),
     settings = require("../lib/reverse-proxy-rate-limiter/settings"),
     createTestRateLimiter = require('./helpers').createTestLimitsEvaluator;
 
 describe("Default settings values", function () {
-    var rl;
+    let rl;
     before(function() {
         // the rateLimiter created by createTestLimitsEvaluator does not start a proxy so it doesn't need to be terminated
-        var s = settings.load();
+        const s = settings.load();
         rl = createTestRateLimiter(s);
     });
 
     it("config endpoint should be set to valid URL", function () {
-        expect(rl.getConfigEndpoint()).to.be("http://localhost:8000/rate-limiter/");
+        expect(rl.getConfigEndpoint()).toBe("http://localhost:8000/rate-limiter/");
     });
 
-    it("should be 60000", function () {
-        expect(rl.getConfigRefreshInterval()).to.be(60000);
+    it("refresh interval should be 0", function () {
+        expect(rl.getConfigRefreshInterval()).toBe(0);
     });
 
     it("should validate the options", function () {
-        var testSettings = {
+        const testSettings = {
             forwardHost: "example.com",
             forwardPort: 9001,
             configEndpoint: "test_endpoint"
         };
-        expect(settings.updateDerivedSettings(testSettings).fullConfigEndpoint).to.be("http://example.com:9001/test_endpoint");
+        expect(settings.updateDerivedSettings(testSettings).fullConfigEndpoint).toBe("http://example.com:9001/test_endpoint");
 
-        var testSettings1 = {
+        const testSettings1 = {
             forwardHost: "example.com",
             forwardPort: 9001,
             configEndpoint: "/test_endpoint"
         };
-        expect(settings.updateDerivedSettings(testSettings1).fullConfigEndpoint).to.be("http://example.com:9001/test_endpoint");
+        expect(settings.updateDerivedSettings(testSettings1).fullConfigEndpoint).toBe("http://example.com:9001/test_endpoint");
 
-        var testSettings2 = {
+        const testSettings2 = {
             forwardHost: "example.com/",
             forwardPort: 9001,
             configEndpoint: "/test_endpoint"
         };
-        expect(settings.updateDerivedSettings(testSettings2).fullConfigEndpoint).to.be("http://example.com/test_endpoint");
+        expect(settings.updateDerivedSettings(testSettings2).fullConfigEndpoint).toBe("http://example.com/test_endpoint");
 
-        var testSettings3 = {
+        const testSettings3 = {
             forwardHost: "localhost",
             forwardPort: "9001",
             configEndpoint: "test_endpoint"
         };
-        expect(settings.updateDerivedSettings(testSettings3).fullConfigEndpoint).to.be("http://localhost:9001/test_endpoint");
+        expect(settings.updateDerivedSettings(testSettings3).fullConfigEndpoint).toBe("http://localhost:9001/test_endpoint");
 
-        var testSettings4 = {
+        const testSettings4 = {
             forwardHost: "localhost",
             forwardPort: "test",
             configEndpoint: "test_endpoint"
         };
-        expect(settings.updateDerivedSettings(testSettings4).fullConfigEndpoint).to.be("http://localhost/test_endpoint");
+        expect(settings.updateDerivedSettings(testSettings4).fullConfigEndpoint).toBe("http://localhost/test_endpoint");
     });
 });


### PR DESCRIPTION
Notable changes:
- lodash - had to change some functioncalls because of incompatibility with older _
- mocha - the '--exit' behaviour is not the default, so had to make some changes so test running terminates after tests succeed
  - most importantly the default configRefreshInterval is set to 0 now so we do not start timers (setInterval) by default
- expect.js was replaced with expect
- vars were changed to consts/lets with the IDE support